### PR TITLE
fixes memory corruption error

### DIFF
--- a/vikit_common/src/vision.cpp
+++ b/vikit_common/src/vision.cpp
@@ -88,7 +88,7 @@ halfSample(const cv::Mat& in, cv::Mat& out)
   }
 #endif
 
-  const int stride = in.step.p[0];
+  const int stride = in.step.p[0]/2*2;
   uint8_t* top = (uint8_t*) in.data;
   uint8_t* bottom = top + stride;
   uint8_t* end = top + stride*in.rows;


### PR DESCRIPTION
This simple fix resolves an issue with the image pyramid when the image width is not a multiple of 16 (because with the default parameters, the pyramid has 5 levels and therefore the image width is halved 4 times).
I had this issue last year and fixed it but never actually created the pull request.
Thanks!
