### PR TITLE
Fix compatibility with Sophus

### DIFF
--- a/vikit_common/include/vikit/img_align.h
+++ b/vikit_common/include/vikit/img_align.h
@@ -18,7 +18,7 @@
 #include <vikit/pinhole_camera.h>
 #include <vikit/nlls_solver.h>
 #include <vikit/performance_monitor.h>
-#include <sophus/se3.h>
+#include <sophus/se3.hpp>
 
 namespace vk {
 

--- a/vikit_common/include/vikit/math_utils.h
+++ b/vikit_common/include/vikit/math_utils.h
@@ -11,7 +11,7 @@
 
 #include <Eigen/Core>
 #include <Eigen/StdVector>
-#include <sophus/se3.h>
+#include <sophus/se3.hpp>
 
 namespace vk
 {

--- a/vikit_common/src/homography.cpp
+++ b/vikit_common/src/homography.cpp
@@ -31,7 +31,7 @@ void Homography::
 calcFromPlaneParams(const Vector3d& n_c1, const Vector3d& xyz_c1)
 {
   double d = n_c1.dot(xyz_c1); // normal distance from plane to KF
-  H_c2_from_c1 = T_c2_from_c1.rotation_matrix() + (T_c2_from_c1.translation()*n_c1.transpose())/d;
+  H_c2_from_c1 = T_c2_from_c1.rotationMatrix() + (T_c2_from_c1.translation()*n_c1.transpose())/d;
 }
 
 void Homography::
@@ -260,7 +260,7 @@ findBestDecomposition()
     for(size_t i=0; i<2; i++)
     {
       Sophus::SE3 T = decompositions[i].T;
-      Matrix3d Essential = T.rotation_matrix() * sqew(T.translation());
+      Matrix3d Essential = T.rotationMatrix() * sqew(T.translation());
       double dSumError = 0;
       for(size_t m=0; m < fts_c1.size(); m++ )
       {

--- a/vikit_common/src/img_align.cpp
+++ b/vikit_common/src/img_align.cpp
@@ -20,7 +20,7 @@
 #include <vikit/nlls_solver.h>
 #include <vikit/performance_monitor.h>
 #include <vikit/img_align.h>
-#include <sophus/se3.h>
+#include <sophus/se3.hpp>
 
 namespace vk {
 

--- a/vikit_ros/include/vikit/output_helper.h
+++ b/vikit_ros/include/vikit/output_helper.h
@@ -11,7 +11,7 @@
 #include <string>
 #include <ros/ros.h>
 #include <Eigen/Core>
-#include <sophus/se3.h>
+#include <sophus/se3.hpp>
 #include <tf/transform_broadcaster.h>
 
 namespace vk {

--- a/vikit_ros/src/output_helper.cpp
+++ b/vikit_ros/src/output_helper.cpp
@@ -17,7 +17,7 @@ publishTfTransform(const Sophus::SE3& T, const ros::Time& stamp,
                    tf::TransformBroadcaster& br)
 {
   tf::Transform transform_msg;
-  Eigen::Quaterniond q(T.rotation_matrix());
+  Eigen::Quaterniond q(T.rotationMatrix());
   transform_msg.setOrigin(tf::Vector3(T.translation().x(), T.translation().y(), T.translation().z()));
   tf::Quaternion tf_q; tf_q.setX(q.x()); tf_q.setY(q.y()); tf_q.setZ(q.z()); tf_q.setW(q.w());
   transform_msg.setRotation(tf_q);


### PR DESCRIPTION
fix sophus se3.h include and rotation_matrix Eigen bug

Vikit would not compile with latest versions of Sophus.
The header files changed from *.h to *.hpp
rotation_matrix() is deprecated and produces Eigen matrix errors during compilation
